### PR TITLE
Implement new KangarooTwelve - KT128 and KT256

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,15 @@ clean: ## Removes cargo target directory
 	cargo clean
 
 .PHONY: example
-example: ## Runs the K12 example program
-	RUSTFLAGS="-C target-cpu=native" cargo run --example k12
-	RUSTFLAGS="-C target-cpu=native" cargo run --example k12 --features multi_threaded
+example: ## Runs the KT128 and KT256 example program
+	RUSTFLAGS="-C target-cpu=native" cargo run --example kt128
+	RUSTFLAGS="-C target-cpu=native" cargo run --example kt256
+	RUSTFLAGS="-C target-cpu=native" cargo run --example kt128 --features multi_threaded
+	RUSTFLAGS="-C target-cpu=native" cargo run --example kt256 --features multi_threaded
 
 .PHONY: example-wasm
-example-wasm: ## Runs the K12 example program in WASM environment
-	cargo run --example k12 --target wasm32-wasip1 --no-default-features
-	cargo run --example k12 --target wasm32-wasip2 --no-default-features
+example-wasm: ## Runs the KT128 and KT256 example program in WASM environment
+	cargo run --example kt128 --target wasm32-wasip1 --no-default-features
+	cargo run --example kt256 --target wasm32-wasip1 --no-default-features
+	cargo run --example kt128 --target wasm32-wasip2 --no-default-features
+	cargo run --example kt256 --target wasm32-wasip2 --no-default-features

--- a/benches/kangarootwelve.rs
+++ b/benches/kangarootwelve.rs
@@ -1,4 +1,4 @@
-use kangarootwelve::KT128;
+use kangarootwelve::{KT128, KT256};
 use rand::Rng;
 use std::{fmt::Debug, time::Duration};
 
@@ -69,7 +69,7 @@ const ARGS: &[K12Config] = &[
 ];
 
 #[divan::bench(args = ARGS, max_time = Duration::from_secs(100), skip_ext_time = true)]
-fn k12(bencher: divan::Bencher, k12_config: &K12Config) {
+fn kt128(bencher: divan::Bencher, k12_config: &K12Config) {
     let mut rng = rand::rng();
     let msg = (0..k12_config.msg_byte_len).map(|_| rng.random()).collect::<Vec<u8>>();
 
@@ -78,6 +78,20 @@ fn k12(bencher: divan::Bencher, k12_config: &K12Config) {
         .with_inputs(|| vec![0u8; k12_config.digest_byte_len])
         .bench_refs(|digest| {
             let mut hasher = KT128::hash(divan::black_box(&msg), divan::black_box(&[]));
+            hasher.squeeze(divan::black_box(digest));
+        });
+}
+
+#[divan::bench(args = ARGS, max_time = Duration::from_secs(100), skip_ext_time = true)]
+fn kt256(bencher: divan::Bencher, k12_config: &K12Config) {
+    let mut rng = rand::rng();
+    let msg = (0..k12_config.msg_byte_len).map(|_| rng.random()).collect::<Vec<u8>>();
+
+    bencher
+        .counter(divan::counter::BytesCount::new(k12_config.msg_byte_len + k12_config.digest_byte_len))
+        .with_inputs(|| vec![0u8; k12_config.digest_byte_len])
+        .bench_refs(|digest| {
+            let mut hasher = KT256::hash(divan::black_box(&msg), divan::black_box(&[]));
             hasher.squeeze(divan::black_box(digest));
         });
 }

--- a/benches/kangarootwelve.rs
+++ b/benches/kangarootwelve.rs
@@ -1,4 +1,4 @@
-use kangarootwelve::KangarooTwelve;
+use kangarootwelve::KT128;
 use rand::Rng;
 use std::{fmt::Debug, time::Duration};
 
@@ -77,7 +77,7 @@ fn k12(bencher: divan::Bencher, k12_config: &K12Config) {
         .counter(divan::counter::BytesCount::new(k12_config.msg_byte_len + k12_config.digest_byte_len))
         .with_inputs(|| vec![0u8; k12_config.digest_byte_len])
         .bench_refs(|digest| {
-            let mut hasher = KangarooTwelve::hash(divan::black_box(&msg), divan::black_box(&[]));
+            let mut hasher = KT128::hash(divan::black_box(&msg), divan::black_box(&[]));
             hasher.squeeze(divan::black_box(digest));
         });
 }

--- a/examples/kt128.rs
+++ b/examples/kt128.rs
@@ -1,4 +1,4 @@
-use kangarootwelve::KangarooTwelve;
+use kangarootwelve::KT128;
 use rand::RngCore;
 
 fn main() {
@@ -14,10 +14,11 @@ fn main() {
     rng.fill_bytes(&mut msg);
     cstr[0] = 0xff;
 
-    let mut hasher = KangarooTwelve::hash(&msg, &cstr);
+    let mut hasher = KT128::hash(&msg, &cstr);
     hasher.squeeze(&mut dig[..DLEN / 2]);
     hasher.squeeze(&mut dig[DLEN / 2..]);
 
+    println!("Using KT128");
     println!("Message              = {}", const_hex::encode(&msg));
     println!("Customization String = {}", const_hex::encode(&cstr));
     println!("Digest               = {}", const_hex::encode(&dig));

--- a/examples/kt256.rs
+++ b/examples/kt256.rs
@@ -1,0 +1,25 @@
+use kangarootwelve::KT256;
+use rand::RngCore;
+
+fn main() {
+    const MLEN: usize = 64;
+    const CSTRLEN: usize = 1;
+    const DLEN: usize = 32;
+
+    let mut msg = vec![0u8; MLEN];
+    let mut cstr = vec![0u8; CSTRLEN];
+    let mut dig = vec![0u8; DLEN];
+
+    let mut rng = rand::rng();
+    rng.fill_bytes(&mut msg);
+    cstr[0] = 0xff;
+
+    let mut hasher = KT256::hash(&msg, &cstr);
+    hasher.squeeze(&mut dig[..DLEN / 2]);
+    hasher.squeeze(&mut dig[DLEN / 2..]);
+
+    println!("Using KT256");
+    println!("Message              = {}", const_hex::encode(&msg));
+    println!("Customization String = {}", const_hex::encode(&cstr));
+    println!("Digest               = {}", const_hex::encode(&dig));
+}

--- a/src/kt128.rs
+++ b/src/kt128.rs
@@ -5,17 +5,17 @@ use turboshake::{TurboShake128, sponge};
 #[cfg(feature = "multi_threaded")]
 use rayon::{ThreadPoolBuilder, prelude::*};
 
-/// KangarooTwelve Extendable Output Function (XOF)
+/// KT128 Extendable Output Function (XOF)
 ///
-/// See https://keccak.team/files/KangarooTwelve.pdf
+/// See <https://keccak.team/files/KangarooTwelve.pdf> and <https://datatracker.ietf.org/doc/draft-irtf-cfrg-kangarootwelve>
 #[derive(Copy, Clone)]
-pub struct KangarooTwelve {
+pub struct KT128 {
     state: [u64; 25],
     is_ready: usize,
     squeezable: usize,
 }
 
-impl KangarooTwelve {
+impl KT128 {
     const CAPACITY_BITS: usize = 256;
     const RATE_BITS: usize = 1600 - Self::CAPACITY_BITS;
     const RATE_BYTES: usize = Self::RATE_BITS / 8;
@@ -81,10 +81,10 @@ impl KangarooTwelve {
 
     /// Given message (M) and customization string (C, which can be used for domain seperation)
     /// this routine consumes both of them into Keccak\[256\] sponge state, using single thread,
-    /// in chunks of B -bytes s.t. returned K12 object can be used for squeezing arbitrary number
+    /// in chunks of B -bytes s.t. returned KT128 object can be used for squeezing arbitrary number
     /// of bytes from sponge state.
     ///
-    /// This is a single-threaded implementation of the K12 tree hash mode, as described in section 3.3
+    /// This is a single-threaded implementation of the KT128 tree hash mode, as described in section 3.3
     /// of the specification https://keccak.team/files/KangarooTwelve.pdf. You haven't configured this library
     /// crate to use `multi_threaded` feature.
     ///
@@ -149,9 +149,9 @@ impl KangarooTwelve {
     /// Given message (M) and customization string (C, which can be used for domain seperation)
     /// this routine consumes both of them into Keccak\[256\] sponge state, using multiple threads i.e.
     /// equals to # -of logical cores supported by execution environment, in chunks of B -bytes s.t.
-    /// returned K12 object can be used for squeezing arbitrary number of bytes from sponge state.
+    /// returned KT128 object can be used for squeezing arbitrary number of bytes from sponge state.
     ///
-    /// This is a multi-threaded implementation of the K12 tree hash mode, as described in section 3.3
+    /// This is a multi-threaded implementation of the KT128 tree hash mode, as described in section 3.3
     /// of the specification https://keccak.team/files/KangarooTwelve.pdf. You're using this function because
     /// you have configured this library crate to use `multi_threaded` feature.
     ///
@@ -226,11 +226,6 @@ impl KangarooTwelve {
     ///
     /// Note, this routine can be called arbitrary number of times, for squeezing arbitrary
     /// number of bytes from sponge Keccak\[256\].
-    ///
-    /// Make sure you absorb message bytes first, then only call this function, otherwise
-    /// it can't squeeze anything out.
-    ///
-    /// Adapted from https://github.com/itzmeanjan/turboshake/blob/81243e8e/src/turboshake128.rs#L87-L109
     #[inline(always)]
     pub fn squeeze(&mut self, out: &mut [u8]) {
         if self.is_ready != usize::MAX {

--- a/src/kt128.rs
+++ b/src/kt128.rs
@@ -93,7 +93,7 @@ impl KT128 {
     pub fn hash(msg: &[u8], cstr: &[u8]) -> Self {
         let (enc, elen) = length_encode(cstr.len());
         let tlen = msg.len() + cstr.len() + elen;
-        let n = (tlen + (Self::B - 1)) / Self::B;
+        let n = tlen.div_ceil(Self::B);
 
         if n == 1 {
             let mut state = [0u64; 25];

--- a/src/kt256.rs
+++ b/src/kt256.rs
@@ -1,0 +1,237 @@
+use crate::utils::length_encode;
+use std::cmp;
+use turboshake::{TurboShake256, sponge};
+
+#[cfg(feature = "multi_threaded")]
+use rayon::{ThreadPoolBuilder, prelude::*};
+
+/// KT256 Extendable Output Function (XOF)
+///
+/// See <https://datatracker.ietf.org/doc/draft-irtf-cfrg-kangarootwelve>
+#[derive(Copy, Clone)]
+pub struct KT256 {
+    state: [u64; 25],
+    is_ready: usize,
+    squeezable: usize,
+}
+
+impl KT256 {
+    const CAPACITY_BITS: usize = 512;
+    const RATE_BITS: usize = 1600 - Self::CAPACITY_BITS;
+    const RATE_BYTES: usize = Self::RATE_BITS / 8;
+    const RATE_WORDS: usize = Self::RATE_BYTES / 8;
+    const B: usize = 8192;
+    const D_SEP_A: u8 = 0x07;
+    const D_SEP_B: u8 = 0x0b;
+    const D_SEP_C: u8 = 0x06;
+
+    /// Given message (M), customization string (C) and length of C encoded using `length_encode()`
+    /// function ( s.t. only first `elen` bytes are of interest ), this routine extracts out `i` -th
+    /// chunk ( s.t. each chunk is `B` -bytes wide ) along with how many ( must be <= B ) bytes
+    /// of that chunk are of significance.
+    ///
+    /// For understanding how this function works, let us assume
+    ///
+    /// S <- M || C || length_encode(|C|) s.t. |C| <- byte length of C
+    ///
+    /// We can split S into `n` -chunks s.t. first (n - 1) chunks are of length B while the
+    /// last one is of length <= B. So n = ⌈|S|/ B⌉
+    ///
+    /// n must be 1, because it's guaranteed that S will be atleast 1 -byte wide even if both M
+    /// and C are empty. Then it must be the case that 0 <= i < n.
+    ///
+    /// You may want to take a look at section 3.{2, 3} of the K12 specification
+    /// https://keccak.team/files/KangarooTwelve.pdf for understanding why this function exists.
+    #[inline(always)]
+    fn get_ith_chunk(i: usize, msg: &[u8], cstr: &[u8], enc: &[u8]) -> ([u8; Self::B], usize) {
+        let l0 = msg.len();
+        let l1 = l0 + cstr.len();
+        let l2 = l1 + enc.len();
+
+        let mut res = [0u8; Self::B];
+        let mut off = 0;
+
+        let start_at = i * Self::B;
+
+        if start_at < l0 {
+            let readable = cmp::min(l0 - start_at, Self::B);
+            res[..readable].copy_from_slice(&msg[start_at..(start_at + readable)]);
+
+            off += readable;
+        }
+
+        if (off < Self::B) && ((start_at + off) < l1) {
+            let readable = cmp::min(l1 - (start_at + off), Self::B - off);
+            let tmp = (start_at + off) - l0;
+            res[off..(off + readable)].copy_from_slice(&cstr[tmp..(tmp + readable)]);
+
+            off += readable;
+        }
+
+        if (off < Self::B) && ((start_at + off) < l2) {
+            let readable = cmp::min(l2 - (start_at + off), Self::B - off);
+            let tmp = (start_at + off) - l1;
+            res[off..(off + readable)].copy_from_slice(&enc[tmp..(tmp + readable)]);
+
+            off += readable;
+        }
+
+        (res, off)
+    }
+
+    /// Given message (M) and customization string (C, which can be used for domain seperation)
+    /// this routine consumes both of them into Keccak\[512\] sponge state, using single thread,
+    /// in chunks of B -bytes s.t. returned KT256 object can be used for squeezing arbitrary number
+    /// of bytes from sponge state.
+    ///
+    /// This is a single-threaded implementation of the KT256 tree hash mode, as described in section 3.4
+    /// of the specification https://datatracker.ietf.org/doc/draft-irtf-cfrg-kangarootwelve. You haven't
+    /// configured this library crate to use `multi_threaded` feature.
+    ///
+    /// You can use this function for oneshot hashing i.e. when all the input bytes are ready to be consumed.
+    #[cfg(not(feature = "multi_threaded"))]
+    pub fn hash(msg: &[u8], cstr: &[u8]) -> Self {
+        let (enc, elen) = length_encode(cstr.len());
+        let tlen = msg.len() + cstr.len() + elen;
+        let n = (tlen + (Self::B - 1)) / Self::B;
+
+        if n == 1 {
+            let mut state = [0u64; 25];
+            let mut offset = 0;
+
+            let (chunk, clen) = Self::get_ith_chunk(0, msg, cstr, &enc[..elen]);
+
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &chunk[..clen]);
+            sponge::finalize::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }, { Self::D_SEP_A }>(&mut state, &mut offset);
+
+            Self {
+                state,
+                is_ready: usize::MAX,
+                squeezable: Self::RATE_BYTES,
+            }
+        } else {
+            let mut state = [0u64; 25];
+            let mut offset = 0;
+
+            let (chunk, _) = Self::get_ith_chunk(0, msg, cstr, &enc[..elen]);
+            const PAD_A: [u8; 8] = [3, 0, 0, 0, 0, 0, 0, 0];
+            const PAD_B: [u8; 2] = [0xff, 0xff];
+
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &chunk);
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &PAD_A);
+
+            for i in 1..n {
+                let (chunk, clen) = Self::get_ith_chunk(i, msg, cstr, &enc[..elen]);
+                let mut cv = [0u8; 64];
+
+                let mut hasher = TurboShake256::new();
+                hasher.absorb(&chunk[..clen]);
+                hasher.finalize::<{ Self::D_SEP_B }>();
+                hasher.squeeze(&mut cv);
+
+                sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &cv);
+            }
+
+            let (enc, elen) = length_encode(n - 1);
+
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &enc[..elen]);
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &PAD_B);
+            sponge::finalize::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }, { Self::D_SEP_C }>(&mut state, &mut offset);
+
+            Self {
+                state,
+                is_ready: usize::MAX,
+                squeezable: Self::RATE_BYTES,
+            }
+        }
+    }
+
+    /// Given message (M) and customization string (C, which can be used for domain seperation)
+    /// this routine consumes both of them into Keccak\[512\] sponge state, using multiple threads i.e.
+    /// equals to # -of logical cores supported by execution environment, in chunks of B -bytes s.t.
+    /// returned KT256 object can be used for squeezing arbitrary number of bytes from sponge state.
+    ///
+    /// This is a multi-threaded implementation of the KT256 tree hash mode, as described in section 3.4
+    /// of the specification https://datatracker.ietf.org/doc/draft-irtf-cfrg-kangarootwelve. You're using
+    /// this function because you have configured this library crate to use `multi_threaded` feature.
+    ///
+    /// You can use this function for oneshot hashing i.e. when all the input bytes are ready to be consumed.
+    #[cfg(feature = "multi_threaded")]
+    pub fn hash(msg: &[u8], cstr: &[u8]) -> Self {
+        let (enc, elen) = length_encode(cstr.len());
+        let tlen = msg.len() + cstr.len() + elen;
+        let n = (tlen + (Self::B - 1)) / Self::B;
+
+        if n == 1 {
+            let mut state = [0u64; 25];
+            let mut offset = 0;
+
+            let (chunk, clen) = Self::get_ith_chunk(0, msg, cstr, &enc[..elen]);
+
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &chunk[..clen]);
+            sponge::finalize::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }, { Self::D_SEP_A }>(&mut state, &mut offset);
+
+            Self {
+                state,
+                is_ready: usize::MAX,
+                squeezable: Self::RATE_BYTES,
+            }
+        } else {
+            let mut state = [0u64; 25];
+            let mut offset = 0;
+
+            let (chunk, _) = Self::get_ith_chunk(0, msg, cstr, &enc[..elen]);
+            const PAD_A: [u8; 8] = [3, 0, 0, 0, 0, 0, 0, 0];
+            const PAD_B: [u8; 2] = [0xff, 0xff];
+
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &chunk);
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &PAD_A);
+
+            let cpus = cmp::min(num_cpus::get(), n - 1);
+            let pool = ThreadPoolBuilder::new().num_threads(cpus).build().unwrap();
+            let cvs = pool.install(|| {
+                let mut cvs = vec![0u8; (n - 1) * 64];
+
+                cvs.par_chunks_mut(64).enumerate().for_each(|(i, cv)| {
+                    let (chunk, clen) = Self::get_ith_chunk(i + 1, msg, cstr, &enc[..elen]);
+
+                    let mut hasher = TurboShake256::new();
+                    hasher.absorb(&chunk[..clen]);
+                    hasher.finalize::<{ Self::D_SEP_B }>();
+                    hasher.squeeze(cv);
+                });
+
+                cvs
+            });
+
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &cvs);
+
+            let (enc, elen) = length_encode(n - 1);
+
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &enc[..elen]);
+            sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut state, &mut offset, &PAD_B);
+            sponge::finalize::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }, { Self::D_SEP_C }>(&mut state, &mut offset);
+
+            Self {
+                state,
+                is_ready: usize::MAX,
+                squeezable: Self::RATE_BYTES,
+            }
+        }
+    }
+
+    /// Given that N -bytes input message ( along with customization string ) is already
+    /// absorbed into sponge state, this routine is used for squeezing M -bytes out of
+    /// consumable part of the sponge state ( i.e. rate portion of the state ).
+    ///
+    /// Note, this routine can be called arbitrary number of times, for squeezing arbitrary
+    /// number of bytes from sponge Keccak\[512\].
+    #[inline(always)]
+    pub fn squeeze(&mut self, out: &mut [u8]) {
+        if self.is_ready != usize::MAX {
+            return;
+        }
+
+        sponge::squeeze::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(&mut self.state, &mut self.squeezable, out);
+    }
+}

--- a/src/kt256.rs
+++ b/src/kt256.rs
@@ -93,7 +93,7 @@ impl KT256 {
     pub fn hash(msg: &[u8], cstr: &[u8]) -> Self {
         let (enc, elen) = length_encode(cstr.len());
         let tlen = msg.len() + cstr.len() + elen;
-        let n = (tlen + (Self::B - 1)) / Self::B;
+        let n = tlen.div_ceil(Self::B);
 
         if n == 1 {
             let mut state = [0u64; 25];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 mod kt128;
+mod kt256;
 mod tests;
 mod utils;
 
 pub use kt128::KT128;
+pub use kt256::KT256;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-mod kangarootwelve;
+mod kt128;
 mod tests;
 mod utils;
 
-pub use kangarootwelve::KangarooTwelve;
+pub use kt128::KT128;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::KT128;
+use crate::{KT128, KT256};
 use std::cmp;
 
 /// Generates static byte pattern of length 251, following
@@ -33,6 +33,15 @@ fn ptn(n: usize) -> Vec<u8> {
 fn kt128(msg: &[u8], cstr: &[u8], olen: usize) -> Vec<u8> {
     let mut out = vec![0u8; olen];
     KT128::hash(msg, cstr).squeeze(&mut out);
+
+    out
+}
+
+/// Helper function for computing KT256 digest ( of length olen -bytes ) for some (M, C) pair.
+#[allow(dead_code)]
+fn kt256(msg: &[u8], cstr: &[u8], olen: usize) -> Vec<u8> {
+    let mut out = vec![0u8; olen];
+    KT256::hash(msg, cstr).squeeze(&mut out);
 
     out
 }
@@ -130,5 +139,101 @@ fn known_answer_test_for_kt128() {
     assert_eq!(
         const_hex::encode(kt128(&ptn(8192), &ptn(8190), 32)),
         "6a7c1b6a5cd0d8c9ca943a4a216cc64604559a2ea45f78570a15253d67ba00ae"
+    );
+}
+
+/// Ensures functional correctness of KT256 ( non-incremental hashing API ) using test vectors
+/// collected from https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#name-test-vectors
+/// and using pseudocode https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#name-kt256
+#[test]
+fn known_answer_test_for_kt256() {
+    assert_eq!(
+        const_hex::encode(kt256(&[], &[], 64)),
+        "b23d2e9cea9f4904e02bec06817fc10ce38ce8e93ef4c89e6537076af8646404e3e8b68107b8833a5d30490aa33482353fd4adc7148ecb782855003aaebde4a9"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&[], &[], 128)),
+        "b23d2e9cea9f4904e02bec06817fc10ce38ce8e93ef4c89e6537076af8646404e3e8b68107b8833a5d30490aa33482353fd4adc7148ecb782855003aaebde4a9b0925319d8ea1e121a609821ec19efea89e6d08daee1662b69c840289f188ba860f55760b61f82114c030c97e5178449608ccd2cd2d919fc7829ff69931ac4d0"
+    );
+
+    assert_eq!(
+        const_hex::encode(&kt256(&[], &[], 10064)[10000..]),
+        "ad4a1d718cf950506709a4c33396139b4449041fc79a05d68da35f1e453522e056c64fe94958e7085f2964888259b9932752f3ccd855288efee5fcbb8b563069"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(17usize.pow(0)), &[], 64)),
+        "0d005a194085360217128cf17f91e1f71314efa5564539d444912e3437efa17f82db6f6ffe76e781eaa068bce01f2bbf81eacb983d7230f2fb02834a21b1ddd0"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(17usize.pow(1)), &[], 64)),
+        "1ba3c02b1fc514474f06c8979978a9056c8483f4a1b63d0dccefe3a28a2f323e1cdcca40ebf006ac76ef0397152346837b1277d3e7faa9c9653b19075098527b"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(17usize.pow(2)), &[], 64)),
+        "de8ccbc63e0f133ebb4416814d4c66f691bbf8b6a61ec0a7700f836b086cb029d54f12ac7159472c72db118c35b4e6aa213c6562caaa9dcc518959e69b10f3ba"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(17usize.pow(3)), &[], 64)),
+        "647efb49fe9d717500171b41e7f11bd491544443209997ce1c2530d15eb1ffbb598935ef954528ffc152b1e4d731ee2683680674365cd191d562bae753b84aa5"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(17usize.pow(4)), &[], 64)),
+        "b06275d284cd1cf205bcbe57dccd3ec1ff6686e3ed15776383e1f2fa3c6ac8f08bf8a162829db1a44b2a43ff83dd89c3cf1ceb61ede659766d5ccf817a62ba8d"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(17usize.pow(5)), &[], 64)),
+        "9473831d76a4c7bf77ace45b59f1458b1673d64bcd877a7c66b2664aa6dd149e60eab71b5c2bab858c074ded81ddce2b4022b5215935c0d4d19bf511aeeb0772"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(17usize.pow(6)), &[], 64)),
+        "0652b740d78c5e1f7c8dcc1777097382768b7ff38f9a7a20f29f413bb1b3045b31a5578f568f911e09cf44746da84224a5266e96a4a535e871324e4f9c7004da"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&[0xff; 0], &ptn(41usize.pow(0)), 64)),
+        "9280f5cc39b54a5a594ec63de0bb99371e4609d44bf845c2f5b8c316d72b159811f748f23e3fabbe5c3226ec96c62186df2d33e9df74c5069ceecbb4dd10eff6"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&[0xff; 1], &ptn(41usize.pow(1)), 64)),
+        "47ef96dd616f200937aa7847e34ec2feae8087e3761dc0f8c1a154f51dc9ccf845d7adbce57ff64b639722c6a1672e3bf5372d87e00aff89be97240756998853"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&[0xff; 3], &ptn(41usize.pow(2)), 64)),
+        "3b48667a5051c5966c53c5d42b95de451e05584e7806e2fb765eda959074172cb438a9e91dde337c98e9c41bed94c4e0aef431d0b64ef2324f7932caa6f54969"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&[0xff; 7], &ptn(41usize.pow(3)), 64)),
+        "e0911cc00025e1540831e266d94add9b98712142b80d2629e643aac4efaf5a3a30a88cbf4ac2a91a2432743054fbcc9897670e86ba8cec2fc2ace9c966369724"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(8191), &[], 64)),
+        "3081434d93a4108d8d8a3305b89682cebedc7ca4ea8a3ce869fbb73cbe4a58eef6f24de38ffc170514c70e7ab2d01f03812616e863d769afb3753193ba045b20"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(8192), &[], 64)),
+        "c6ee8e2ad3200c018ac87aaa031cdac22121b412d07dc6e0dccbb53423747e9a1c18834d99df596cf0cf4b8dfafb7bf02d139d0c9035725adc1a01b7230a41fa"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(8192), &ptn(8189), 64)),
+        "74e47879f10a9c5d11bd2da7e194fe57e86378bf3c3f7448eff3c576a0f18c5caae0999979512090a7f348af4260d4de3c37f1ecaf8d2c2c96c1d16c64b12496"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt256(&ptn(8192), &ptn(8190), 64)),
+        "f4b5908b929ffe01e0f79ec2f21243d41a396b2e7303a6af1d6399cd6c7a0a2dd7c4f607e8277f9c9b1cb4ab9ddc59d4b92d1fc7558441f1832c3279a4241b8b"
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,24 +1,8 @@
-use crate::KangarooTwelve;
+use crate::KT128;
 use std::cmp;
 
-/// Ensures functional correctness of length encoder function.
-#[test]
-fn test_length_encode() {
-    let (enc, len) = crate::utils::length_encode(0);
-    assert_eq!(enc[..len], [0x00]);
-
-    let (enc, len) = crate::utils::length_encode(1);
-    assert_eq!(enc[..len], [0x01, 0x01]);
-
-    let (enc, len) = crate::utils::length_encode(12);
-    assert_eq!(enc[..len], [0x0c, 0x01]);
-
-    let (enc, len) = crate::utils::length_encode(65538);
-    assert_eq!(enc[..len], [0x01, 0x00, 0x02, 0x03]);
-}
-
 /// Generates static byte pattern of length 251, following
-/// https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-09.html#name-test-vectors
+/// https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#name-test-vectors
 ///
 /// Taken from https://github.com/itzmeanjan/turboshake/blob/81243e8e/src/tests.rs#L4-L9
 #[allow(dead_code)]
@@ -27,7 +11,7 @@ fn pattern() -> [u8; 251] {
 }
 
 /// Generates bytearray of length n by repeating static byte pattern returned by `pattern()`,
-/// following https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-09.html#name-test-vectors
+/// following https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#name-test-vectors
 ///
 /// Taken from https://github.com/itzmeanjan/turboshake/blob/81243e8e/src/tests.rs#L11-L25
 #[allow(dead_code)]
@@ -44,82 +28,107 @@ fn ptn(n: usize) -> Vec<u8> {
     res
 }
 
-/// Helper function for computing K12 digest ( of length olen -bytes ) for some (M, C) pair.
+/// Helper function for computing KT128 digest ( of length olen -bytes ) for some (M, C) pair.
 #[allow(dead_code)]
-fn k12(msg: &[u8], cstr: &[u8], olen: usize) -> Vec<u8> {
+fn kt128(msg: &[u8], cstr: &[u8], olen: usize) -> Vec<u8> {
     let mut out = vec![0u8; olen];
-    KangarooTwelve::hash(msg, cstr).squeeze(&mut out);
+    KT128::hash(msg, cstr).squeeze(&mut out);
 
     out
 }
 
-/// Ensures functions correctness of K12 ( non-incremental hashing API ) using test vectors
-/// collected from https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-09.html#name-test-vectors
-/// and using pseudocode https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-09.html#name-kangarootwelve
+/// Ensures functional correctness of KT128 ( non-incremental hashing API ) using test vectors
+/// collected from https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#name-test-vectors
+/// and using pseudocode https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#name-kt128
 #[test]
-fn test_kangaroo_twelve() {
+fn known_answer_test_for_kt128() {
     assert_eq!(
-        const_hex::encode(k12(&[], &[], 32)),
+        const_hex::encode(kt128(&[], &[], 32)),
         "1ac2d450fc3b4205d19da7bfca1b37513c0803577ac7167f06fe2ce1f0ef39e5"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&[], &[], 64)),
+        const_hex::encode(kt128(&[], &[], 64)),
         "1ac2d450fc3b4205d19da7bfca1b37513c0803577ac7167f06fe2ce1f0ef39e54269c056b8c82e48276038b6d292966cc07a3d4645272e31ff38508139eb0a71"
     );
 
     assert_eq!(
-        const_hex::encode(&k12(&[], &[], 10032)[10000..]),
+        const_hex::encode(&kt128(&[], &[], 10032)[10000..]),
         "e8dc563642f7228c84684c898405d3a834799158c079b12880277a1d28e2ff6d"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&ptn(17usize.pow(0)), &[], 32)),
+        const_hex::encode(kt128(&ptn(17usize.pow(0)), &[], 32)),
         "2bda92450e8b147f8a7cb629e784a058efca7cf7d8218e02d345dfaa65244a1f"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&ptn(17usize.pow(1)), &[], 32)),
+        const_hex::encode(kt128(&ptn(17usize.pow(1)), &[], 32)),
         "6bf75fa2239198db4772e36478f8e19b0f371205f6a9a93a273f51df37122888"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&ptn(17usize.pow(2)), &[], 32)),
+        const_hex::encode(kt128(&ptn(17usize.pow(2)), &[], 32)),
         "0c315ebcdedbf61426de7dcf8fb725d1e74675d7f5327a5067f367b108ecb67c"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&ptn(17usize.pow(3)), &[], 32)),
+        const_hex::encode(kt128(&ptn(17usize.pow(3)), &[], 32)),
         "cb552e2ec77d9910701d578b457ddf772c12e322e4ee7fe417f92c758f0d59d0"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&ptn(17usize.pow(4)), &[], 32)),
+        const_hex::encode(kt128(&ptn(17usize.pow(4)), &[], 32)),
         "8701045e22205345ff4dda05555cbb5c3af1a771c2b89baef37db43d9998b9fe"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&ptn(17usize.pow(5)), &[], 32)),
+        const_hex::encode(kt128(&ptn(17usize.pow(5)), &[], 32)),
         "844d610933b1b9963cbdeb5ae3b6b05cc7cbd67ceedf883eb678a0a8e0371682"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&[0xff; 0], &ptn(41usize.pow(0)), 32)),
+        const_hex::encode(kt128(&ptn(17usize.pow(6)), &[], 32)),
+        "3c390782a8a4e89fa6367f72feaaf13255c8d95878481d3cd8ce85f58e880af8"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt128(&[0xff; 0], &ptn(41usize.pow(0)), 32)),
         "fab658db63e94a246188bf7af69a133045f46ee984c56e3c3328caaf1aa1a583"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&[0xff; 1], &ptn(41usize.pow(1)), 32)),
+        const_hex::encode(kt128(&[0xff; 1], &ptn(41usize.pow(1)), 32)),
         "d848c5068ced736f4462159b9867fd4c20b808acc3d5bc48e0b06ba0a3762ec4"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&[0xff; 3], &ptn(41usize.pow(2)), 32)),
+        const_hex::encode(kt128(&[0xff; 3], &ptn(41usize.pow(2)), 32)),
         "c389e5009ae57120854c2e8c64670ac01358cf4c1baf89447a724234dc7ced74"
     );
 
     assert_eq!(
-        const_hex::encode(k12(&[0xff; 7], &ptn(41usize.pow(3)), 32)),
+        const_hex::encode(kt128(&[0xff; 7], &ptn(41usize.pow(3)), 32)),
         "75d2f86a2e644566726b4fbcfc5657b9dbcf070c7b0dca06450ab291d7443bcf"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt128(&ptn(8191), &[], 32)),
+        "1b577636f723643e990cc7d6a659837436fd6a103626600eb8301cd1dbe553d6"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt128(&ptn(8192), &[], 32)),
+        "48f256f6772f9edfb6a8b661ec92dc93b95ebd05a08a17b39ae3490870c926c3"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt128(&ptn(8192), &ptn(8189), 32)),
+        "3ed12f70fb05ddb58689510ab3e4d23c6c6033849aa01e1d8c220a297fedcd0b"
+    );
+
+    assert_eq!(
+        const_hex::encode(kt128(&ptn(8192), &ptn(8190), 32)),
+        "6a7c1b6a5cd0d8c9ca943a4a216cc64604559a2ea45f78570a15253d67ba00ae"
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,7 @@ use std::cmp;
 /// Taken from https://github.com/itzmeanjan/turboshake/blob/81243e8e/src/tests.rs#L4-L9
 #[allow(dead_code)]
 fn pattern() -> [u8; 251] {
-    (0..251).map(|i| i).collect::<Vec<u8>>().try_into().unwrap()
+    (0..251).collect::<Vec<u8>>().try_into().unwrap()
 }
 
 /// Generates bytearray of length n by repeating static byte pattern returned by `pattern()`,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,4 @@
 use crate::{KT128, KT256};
-use std::cmp;
 
 /// Generates static byte pattern of length 251, following
 /// https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#name-test-vectors
@@ -16,16 +15,7 @@ fn pattern() -> [u8; 251] {
 /// Taken from https://github.com/itzmeanjan/turboshake/blob/81243e8e/src/tests.rs#L11-L25
 #[allow(dead_code)]
 fn ptn(n: usize) -> Vec<u8> {
-    let mut res = vec![0; n];
-
-    let mut off = 0;
-    while off < n {
-        let read = cmp::min(n - off, 251);
-        res[off..(off + read)].copy_from_slice(&pattern()[..read]);
-        off += read;
-    }
-
-    res
+    (0..(n.div_ceil(251))).flat_map(|_| pattern()).take(n).collect::<Vec<u8>>()
 }
 
 /// Helper function for computing KT128 digest ( of length olen -bytes ) for some (M, C) pair.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,3 +22,23 @@ pub fn length_encode(x: usize) -> ([u8; core::mem::size_of::<usize>() + 1], usiz
 
     (res, l + 1)
 }
+
+#[cfg(test)]
+mod test {
+    use crate::utils::length_encode;
+
+    #[test]
+    fn test_length_encode() {
+        let (enc, len) = length_encode(0);
+        assert_eq!(enc[..len], [0x00]);
+
+        let (enc, len) = length_encode(1);
+        assert_eq!(enc[..len], [0x01, 0x01]);
+
+        let (enc, len) = length_encode(12);
+        assert_eq!(enc[..len], [0x0c, 0x01]);
+
+        let (enc, len) = length_encode(65538);
+        assert_eq!(enc[..len], [0x01, 0x00, 0x02, 0x03]);
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,7 +13,7 @@ pub fn length_encode(x: usize) -> ([u8; core::mem::size_of::<usize>() + 1], usiz
     let mut res = [0u8; core::mem::size_of::<usize>() + 1];
 
     let bw = usize::MAX.count_ones() - x.leading_zeros();
-    let l = ((bw + 7) / 8) as usize;
+    let l = bw.div_ceil(8) as usize;
 
     for i in 0..l {
         res[l - i - 1] = (x >> (i * 8)) as u8;


### PR DESCRIPTION
- Resolves #13 
- Resolves #14 
- Add new known answer tests from https://datatracker.ietf.org/doc/draft-irtf-cfrg-kangarootwelve
- Update documentation
- Add new benchmark results